### PR TITLE
docs: add CONTRIBUTING.md root and per-package (issue #5)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to BridgetOS Open Source
+
+## Filing an issue
+
+Open issues on the upstream repository: https://github.com/theloopislooping/bridgetos-oss/issues
+
+- **Bug report**: include the package name, Python version, minimal reproduction, and the full error output.
+- **Feature request**: describe the use case, not just the solution. Mention which package is affected.
+- Check existing issues before opening a new one.
+
+## Opening a pull request
+
+1. Fork the upstream repository and clone your fork.
+2. Create a branch from `main`: `git checkout -b feat/my-change` or `fix/short-description`.
+3. Make your change. Each package under `packages/` is independent — work inside its directory.
+4. Ensure CI passes locally before pushing (see each package's `CONTRIBUTING.md` for commands).
+5. Open a PR against `main` on the upstream repository with a clear description of what changed and why.
+
+CI must be green before a PR is reviewed. One approving review is required to merge. PRs are merged via squash merge.
+
+## Commit message convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/).
+
+```
+feat: add CrewAI adapter
+fix: handle 429 rate-limit response in Client.observe
+docs: clarify schema versioning rules
+chore: bump ruff to 0.4.0
+test: add prompt injection scenario assertions
+```
+
+The type prefix determines the changelog entry. Use `feat` for new behavior, `fix` for bug fixes, `docs` for documentation only, `chore` for tooling/deps, `test` for test-only changes.
+
+Scope is optional but encouraged for monorepo clarity: `feat(langchain): ...`, `fix(sdk): ...`.
+
+## Development setup
+
+Each package is independently installable. See the package-specific `CONTRIBUTING.md` for setup commands, test instructions, and what counts as a breaking change.
+
+| Package | CONTRIBUTING |
+|---------|-------------|
+| `bridgetos-schema` | [packages/bridgetos-schema/CONTRIBUTING.md](packages/bridgetos-schema/CONTRIBUTING.md) |
+| `bridgetos-sdk-python` | [packages/bridgetos-sdk-python/CONTRIBUTING.md](packages/bridgetos-sdk-python/CONTRIBUTING.md) |
+| `bridgetos-langchain` | [packages/bridgetos-langchain/CONTRIBUTING.md](packages/bridgetos-langchain/CONTRIBUTING.md) |
+| `bridgetos-test-harness` | [packages/bridgetos-test-harness/CONTRIBUTING.md](packages/bridgetos-test-harness/CONTRIBUTING.md) |

--- a/packages/bridgetos-langchain/CONTRIBUTING.md
+++ b/packages/bridgetos-langchain/CONTRIBUTING.md
@@ -16,6 +16,15 @@ uv run pytest
 uv run pytest --cov --cov-report=term-missing
 ```
 
+## Lint and format
+
+```bash
+uv run ruff check src/
+uv run ruff format src/
+```
+
+CI runs both as `--check` (no auto-fix). Fix locally before pushing.
+
 ## Callback architecture
 
 `BridgetOSCallback` follows a two-phase accumulate-then-flush pattern:
@@ -45,4 +54,4 @@ export BRIDGETOS_BASE_URL=https://api.bridgetos.com
 
 Then run a short LangChain chain with `BridgetOSCallback` in the `callbacks` list and verify observations appear in the API.
 
-For unit tests, construct the client with `dry_run=True` (or patch `Client.observe`) so no real HTTP calls are made.
+For unit tests, patch `Client.observe` so no real HTTP calls are made.

--- a/packages/bridgetos-langchain/CONTRIBUTING.md
+++ b/packages/bridgetos-langchain/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to bridgetos-langchain
+
+LangChain `BaseCallbackHandler` adapter. Published as `bridgetos-langchain` on PyPI.
+
+## Setup
+
+```bash
+cd packages/bridgetos-langchain
+uv sync --extra dev
+```
+
+## Test commands
+
+```bash
+uv run pytest
+uv run pytest --cov --cov-report=term-missing
+```
+
+## Callback architecture
+
+`BridgetOSCallback` follows a two-phase accumulate-then-flush pattern:
+
+1. **Accumulate** — `on_tool_end` and `on_tool_error` append to `_pending_tool_calls`.
+2. **Flush** — `on_llm_end` bundles the pending tool calls with the LLM output text into a single `Observation` and submits it via `Client.observe()`.
+
+This produces **one `Observation` per LLM completion**, not one per tool call. Keep this invariant when adding new event hooks — tool-level events should accumulate; LLM-level events should flush.
+
+If `observe()` returns `governance_state == "locked"`, the callback raises `GovernanceLockedError`. Callers must propagate this to halt agent execution.
+
+## Adding new event hooks
+
+1. Identify where in the LangChain callback lifecycle your event fires.
+2. If the event is a tool-level event: accumulate into `_pending_tool_calls` or a similar buffer.
+3. If the event is an LLM-completion event: flush the buffer and call `Client.observe()`.
+4. Add a test that verifies the resulting `Observation` contains the expected content.
+
+## Testing against a real LangChain agent
+
+Set credentials and point at a local or staging API:
+
+```bash
+export BRIDGETOS_API_KEY=your-key
+export BRIDGETOS_BASE_URL=https://api.bridgetos.com
+```
+
+Then run a short LangChain chain with `BridgetOSCallback` in the `callbacks` list and verify observations appear in the API.
+
+For unit tests, construct the client with `dry_run=True` (or patch `Client.observe`) so no real HTTP calls are made.

--- a/packages/bridgetos-schema/CONTRIBUTING.md
+++ b/packages/bridgetos-schema/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to bridgetos-schema
+
+This package is the observation data contract. It is a single JSON Schema file (`observation-v1.json`) with example payloads in `examples/`.
+
+## Validation
+
+```bash
+uv run --with check-jsonschema check-jsonschema --check-metaschema observation-v1.json
+```
+
+This validates the schema file itself against the JSON Schema meta-schema (catches bad `$ref`, unknown keywords, malformed JSON). CI runs this on every push.
+
+## Adding example payloads
+
+Add new files to `examples/`. Each example must be a valid observation that passes schema validation:
+
+```bash
+uv run --with check-jsonschema check-jsonschema --schemafile observation-v1.json examples/my-example.json
+```
+
+Examples should illustrate a realistic use case — not just the minimum required fields.
+
+## Schema versioning rules
+
+`observation-v1.json` is the current version. The version number is part of the filename and the `$id`.
+
+**Non-breaking (no version bump required):**
+- Adding a new optional field (no `required` entry, has a default or is nullable)
+- Expanding an enum to allow additional values
+- Loosening a constraint (e.g., increasing `maxLength`)
+
+**Breaking (requires a new version file `observation-v2.json`):**
+- Removing or renaming any existing field
+- Changing a field's type
+- Making an optional field required
+- Tightening a constraint in a way that would reject previously valid payloads
+
+When bumping to v2, keep `observation-v1.json` in place — existing integrations must not break. Add a `# Deprecated` note to v1 and document the migration path in `examples/`.
+
+## What stays out of scope
+
+The schema describes what agents emit. It does not encode scoring logic, governance thresholds, or anything about the analytic core — those live in the proprietary service.

--- a/packages/bridgetos-sdk-python/CONTRIBUTING.md
+++ b/packages/bridgetos-sdk-python/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to bridgetos-sdk-python
+
+Published as the `bridgetos` package on PyPI.
+
+## Setup
+
+```bash
+cd packages/bridgetos-sdk-python
+uv sync --extra dev
+```
+
+## Test commands
+
+```bash
+# Run all tests
+uv run pytest
+
+# Run a single test
+uv run pytest tests/test_schema.py::test_observation_minimum_fields
+
+# With coverage
+uv run pytest --cov --cov-report=term-missing
+```
+
+## Lint and format
+
+```bash
+uv run ruff check src/
+uv run ruff format src/
+```
+
+CI runs both as `--check` (no auto-fix). Fix locally before pushing.
+
+## Public API surface
+
+The public API is everything exported from `src/bridgetos/__init__.py`. Changes to this surface follow semantic versioning.
+
+**Breaking changes — require a major version bump:**
+- Removing or renaming any exported symbol (`Client`, `AsyncClient`, `Observation`, `ObservationResult`, etc.)
+- Changing the type or removing any required constructor parameter
+- Removing or renaming any field on `ObservationResult` (callers destructure these)
+- Changing the HTTP method or path of any endpoint (`POST /v1/agents/{agent_id}/observe`, etc.)
+- Changing how `governance_state == "locked"` is surfaced (callers gate on this)
+
+**Non-breaking — patch or minor version:**
+- Adding a new optional constructor parameter with a default
+- Adding a new method to `Client` or `AsyncClient`
+- Adding a new optional field to any Pydantic model
+- Internal refactoring with no observable behavior change
+
+## Architecture note
+
+All Pydantic models use `extra="forbid"` — unknown fields raise on construction. `ObservationResult` uses `extra="ignore"` intentionally (the API may add fields the SDK doesn't know about yet). Keep this asymmetry intact.

--- a/packages/bridgetos-test-harness/CONTRIBUTING.md
+++ b/packages/bridgetos-test-harness/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to bridgetos-test-harness
+
+Synthetic drift scenario generator and CLI. Published as `bridgetos-harness` on PyPI.
+
+## Setup
+
+```bash
+cd packages/bridgetos-test-harness
+uv sync --extra dev
+```
+
+## Test commands
+
+```bash
+# Unit tests
+uv run pytest
+
+# Smoke test the CLI (no API key needed)
+uv run bridgetos-harness run --agent-id test-001 --scenario baseline --n 5 --dry-run
+```
+
+## Adding a new drift scenario
+
+### 1. Create the scenario file
+
+Add `src/bridgetos_harness/scenarios/my_scenario.py`:
+
+```python
+from collections.abc import Iterator
+from bridgetos_harness.scenarios.base import Scenario, ScenarioContext
+from bridgetos import Observation
+
+class MyScenario(Scenario):
+    name = "my_scenario"
+    description = "Short description of what this scenario tests."
+    expected_drift = True  # or False for baseline-style scenarios
+
+    def generate(self, context: ScenarioContext) -> Iterator[Observation]:
+        for i in range(context.n):
+            yield Observation(
+                agent_id=context.agent_id,
+                content={"text": f"observation {i}"},
+            )
+```
+
+### 2. Register it
+
+In `src/bridgetos_harness/scenarios/__init__.py`, add to the `SCENARIOS` dict:
+
+```python
+from .my_scenario import MyScenario
+
+SCENARIOS = {
+    ...
+    "my_scenario": MyScenario,
+}
+```
+
+### 3. Add tests
+
+Add `tests/scenarios/test_my_scenario.py` that verifies:
+- The scenario generates the expected number of observations for a given `n`.
+- Each observation has the fields required by the BridgetOS schema.
+- For `expected_drift=True` scenarios: the content is plausibly driftful (e.g., contains injected instructions, off-persona language, unexpected tool calls).
+- For `expected_drift=False` scenarios: the content looks like normal baseline agent output.
+
+## Scenario contract
+
+- `expected_drift = True` — the observations this scenario generates must be the kind a well-calibrated behavioral monitor would flag. If a real BridgetOS API returns `severity == "normal"` for all of them, something is wrong with the scenario.
+- `expected_drift = False` — baseline scenarios. Observations must look like normal agent operation and must not trigger drift alerts under normal conditions.
+- `generate()` must be deterministic given the same `ScenarioContext`. Use `context.seed` to seed any random state.


### PR DESCRIPTION
## Summary

- Adds root `CONTRIBUTING.md` covering issue filing, PR process, Conventional Commits convention, and review policy
- Adds `packages/bridgetos-schema/CONTRIBUTING.md` — schema versioning rules, example payload instructions, when to bump versions
- Adds `packages/bridgetos-sdk-python/CONTRIBUTING.md` — setup/test/lint commands, breaking vs non-breaking API change definitions
- Adds `packages/bridgetos-langchain/CONTRIBUTING.md` — callback accumulate/flush pattern, how to extend hooks, testing against a real agent
- Adds `packages/bridgetos-test-harness/CONTRIBUTING.md` — full step-by-step workflow for adding a new drift scenario

## Acceptance checklist

- [x] Root `CONTRIBUTING.md` exists: issue filing, PR process, Conventional Commits, review policy
- [x] `packages/bridgetos-schema/CONTRIBUTING.md`: versioning rules, example payloads, when to bump
- [x] `packages/bridgetos-sdk-python/CONTRIBUTING.md`: pytest + ruff commands, breaking API change definition
- [x] `packages/bridgetos-langchain/CONTRIBUTING.md`: callback extension pattern, real-agent testing
- [x] `packages/bridgetos-test-harness/CONTRIBUTING.md`: scenario addition workflow (file, register, test)
- [x] Each file is a page or less

Closes #5